### PR TITLE
Bump Kiota helper package versions

### DIFF
--- a/GitHub/GitHub.Octokit.csproj
+++ b/GitHub/GitHub.Octokit.csproj
@@ -8,11 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.6.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.2" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is necessary in order for https://github.com/octokit/source-generator/pull/44 to succeed. New versions were selected by updating to the latest version of Kiota and running `kiota info -l csharp --json`. 