### PR TITLE
maint: Add editorconfig and perform some code clean up

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,188 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs,AsmOffsets.cs}]
+generated_code = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# License header
+file_header_template = Copyright (c) GitHub 2023 — Licensed as MIT.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+[*]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ orleans.codegen.cs
 .ntvs_analysis.dat
 node_modules/
 
+# VS
+.vs/*
+
 # VS Code files for those working on multiple tools
 .vscode/*
 !.vscode/settings.json

--- a/GitHub.Octokit.sln
+++ b/GitHub.Octokit.sln
@@ -3,20 +3,31 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octokit.NET.SDK", "src\Octokit.NET.SDK.csproj", "{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octokit.NET.SDK", "src\Octokit.NET.SDK.csproj", "{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{15BC8D73-8583-4A91-9355-970404126E9B}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4D28588D-BC68-4DCD-9DAD-229FC5CB50CC}
 	EndGlobalSection
 EndGlobal

--- a/src/Authentication/TokenAuthenticationProvider.cs
+++ b/src/Authentication/TokenAuthenticationProvider.cs
@@ -1,3 +1,5 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 
@@ -9,51 +11,57 @@ namespace GitHub.Authentication;
 // TODO: Consider implementing `GitHub Apps` authentication scheme as a separate class
 public class TokenAuthenticationProvider : IAuthenticationProvider
 {
-  private const string AuthorizationHeaderKey = "Authorization";
+    private const string AuthorizationHeaderKey = "Authorization";
 
-  public IAuthenticationProvider TokenAuthProvider {get; private set;}
-  public string ClientId { get; set; }
-  public string Token { get; set; }
+    /// <summary>
+    /// Gets the <see cref="IAuthenticationProvider"/> instance for the token authentication scheme.
+    /// </summary>
+    public IAuthenticationProvider TokenAuthProvider => this;
 
-  /// <summary>
-  /// 
-  /// </summary>
-  /// <param name="clientId"></param>
-  /// <param name="token"></param>
-  /// <exception cref="ArgumentNullException"></exception>
-  public TokenAuthenticationProvider(string clientId, string token)
-	{
-    if (string.IsNullOrEmpty(clientId)) throw new ArgumentNullException(nameof(clientId));
-    if (string.IsNullOrEmpty(token)) throw new ArgumentNullException(nameof(token));
+    /// <summary>
+    /// Gets or sets the client identifier.
+    /// </summary>
+    public string ClientId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the token.
+    /// </summary>
+    public string Token { get; set; }
 
-    ClientId = clientId;
-    Token = token;
-
-    TokenAuthProvider = this;
-  }
-
-  /// <summary>
-  /// Authenticates the application request.
-  /// This currently acts as a synchronous (no await) method - but will change as we do more work on the authentication library.
-  /// </summary>
-  /// <param name="request"></param>
-  /// <param name="additionalAuthenticationContext"></param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  /// <exception cref="ArgumentNullException"></exception>
-  public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
-  {
-
-    if(request == null) throw new ArgumentNullException(nameof(request));
-
-    if (Token == string.Empty)
+    /// <summary>
+    /// Instantiates a new instance of the <see cref="TokenAuthenticationProvider"/> class.
+    /// </summary>
+    /// <param name="clientId">The client identifier to use.</param>
+    /// <param name="token">The token to use.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public TokenAuthenticationProvider(string clientId, string token)
     {
-      throw new ArgumentNullException(nameof(Token));
+        ArgumentNullException.ThrowIfNullOrEmpty(clientId);
+        ArgumentNullException.ThrowIfNullOrEmpty(token);
+
+        ClientId = clientId;
+        Token = token;
     }
 
-    if(!request.Headers.ContainsKey(AuthorizationHeaderKey))
+    /// <summary>
+    /// Authenticates the application request.
+    /// This currently acts as a synchronous (no await) method - but will change as we do more work on the authentication library.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="additionalAuthenticationContext"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
     {
-      request.Headers.Add(AuthorizationHeaderKey, $"Bearer {Token}");
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNullOrEmpty(Token);
+
+        if (!request.Headers.ContainsKey(AuthorizationHeaderKey))
+        {
+            request.Headers.Add(AuthorizationHeaderKey, $"Bearer {Token}");
+        }
+
+        return Task.CompletedTask;
     }
-  }
 }

--- a/src/Client/ClientFactory.cs
+++ b/src/Client/ClientFactory.cs
@@ -1,38 +1,44 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using System.Net;
 using GitHub.Client.Middleware;
 
 namespace GitHub.Client;
 
-
+/// <summary>
+/// Represents a client factory for creating <see cref="HttpClient"/>.
+/// </summary>
 public static class ClientFactory
 {
+    private static readonly Lazy<List<DelegatingHandler>> s_handlers = 
+        new(() => 
+        [
+            new APIVersionHandler(),
+            new UserAgentHandler(),
+        ]);
 
     /// <summary>
-    /// Creates an instance of HttpClient with the specified HttpMessageHandler.
-    /// If no HttpMessageHandler is provided, a default one will be used.
+    /// Creates an <see cref="HttpClient"/> instance with the specified <see cref="HttpMessageHandler"/>.
+    /// If no <see cref="HttpMessageHandler"/> is provided, a default one will be used.
     /// </summary>
-    /// <param name="finalHandler">The final HttpMessageHandler in the chain.</param>
-    /// <returns>An instance of HttpClient.</returns>
+    /// <param name="finalHandler">The final <see cref="HttpMessageHandler"/> in the chain.</param>
+    /// <returns>An instance of <see cref="HttpClient"/>.</returns>
     public static HttpClient Create(HttpMessageHandler? finalHandler = null)
     {
-      var defaultHandlers = CreateDefaultHandlers();
-      var handler = ChainHandlersCollectionAndGetFirstLink(finalHandler ?? GetDefaultHttpMessageHandler(), defaultHandlers.ToArray());
-      return handler != null ? new HttpClient(handler) : new HttpClient();
-    }
+        var defaultHandlers = CreateDefaultHandlers();
 
+        var handler = ChainHandlersCollectionAndGetFirstLink(
+            finalHandler: finalHandler ?? GetDefaultHttpMessageHandler(),
+            handlers: [.. defaultHandlers]);
+
+        return handler is not null ? new HttpClient(handler) : new HttpClient();
+    }
 
     /// <summary>
     /// Creates a list of default delegating handlers for the Octokit client.
     /// </summary>
     /// <returns>A list of default delegating handlers.</returns>
-    public static IList<DelegatingHandler> CreateDefaultHandlers()
-    {
-        return new List<DelegatingHandler>
-        {
-            new APIVersionHandler(),
-            new UserAgentHandler(),
-        };
-    }
+    public static IList<DelegatingHandler> CreateDefaultHandlers() => s_handlers.Value;
 
     /// <summary>
     /// Chains a collection of <see cref="DelegatingHandler"/> instances and returns the first link in the chain.
@@ -42,22 +48,29 @@ public static class ClientFactory
     /// <returns>The first link in the chain of <see cref="DelegatingHandler"/> instances.</returns>
     public static DelegatingHandler? ChainHandlersCollectionAndGetFirstLink(HttpMessageHandler? finalHandler, params DelegatingHandler[] handlers)
     {
-      if(handlers == null || !handlers.Any()) return default;
-      var handlersCount = handlers.Length;
-      for(var i = 0; i < handlersCount; i++)
-      {
-          var handler = handlers[i];
-          var previousItemIndex = i - 1;
-          if(previousItemIndex >= 0)
-          {
-              var previousHandler = handlers[previousItemIndex];
-              previousHandler.InnerHandler = handler;
-          }
-      }
-      if(finalHandler != null) {
-          handlers[handlers.Length-1].InnerHandler = finalHandler;
-      }
-      return handlers.First();
+        if (handlers is null or { Length: 0 })
+        {
+            return default;
+        }
+
+        for (var i = 0; i < handlers.Length; i++)
+        {
+            var handler = handlers[i];
+            var previousItemIndex = i - 1;
+
+            if (previousItemIndex >= 0)
+            {
+                var previousHandler = handlers[previousItemIndex];
+                previousHandler.InnerHandler = handler;
+            }
+        }
+
+        if (finalHandler != null)
+        {
+            handlers[^1].InnerHandler = finalHandler;
+        }
+
+        return handlers.First();
     }
 
     /// <summary>
@@ -65,18 +78,15 @@ public static class ClientFactory
     /// </summary>
     /// <param name="handlers">The collection of <see cref="DelegatingHandler"/> instances to chain.</param>
     /// <returns>The first link in the chain of <see cref="DelegatingHandler"/> instances.</returns>
-    public static DelegatingHandler? ChainHandlersCollectionAndGetFirstLink(params DelegatingHandler[] handlers)
-    {
-      return ChainHandlersCollectionAndGetFirstLink(null, handlers);
-    }
+    public static DelegatingHandler? ChainHandlersCollectionAndGetFirstLink(
+        params DelegatingHandler[] handlers) => 
+        ChainHandlersCollectionAndGetFirstLink(null, handlers);
 
     /// <summary>
-    /// Gets the default HTTP message handler for the Octokit client.
+    /// Gets the default <see cref="HttpMessageHandler"/> for the Octokit client.
     /// </summary>
     /// <param name="proxy">The optional web proxy to use.</param>
     /// <returns>The default HTTP message handler.</returns>
-    public static HttpMessageHandler GetDefaultHttpMessageHandler(IWebProxy? proxy = null)
-    {
-      return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
-    }
+    public static HttpMessageHandler GetDefaultHttpMessageHandler(IWebProxy? proxy = null) =>
+        new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
 }

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -14,7 +14,10 @@ public static class RequestAdapter
     public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider)
     {
         var clientFactory = ClientFactory.Create();
-        var githubRequestAdapter = new HttpClientRequestAdapter(authenticationProvider, null, null, clientFactory, null);
-        return githubRequestAdapter;
+
+        var gitHubRequestAdapter = new HttpClientRequestAdapter(
+            authenticationProvider, null, null, clientFactory, null);
+        
+        return gitHubRequestAdapter;
     }
 }

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -1,7 +1,7 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
-using GitHub.Client.Middleware;
-
 
 namespace GitHub.Client;
 
@@ -13,8 +13,8 @@ public static class RequestAdapter
     /// TODO: Implement the missing props and methods
     public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider)
     {
-      var clientFactory = ClientFactory.Create(); 
-      var githubRequestAdapter = new HttpClientRequestAdapter(authenticationProvider, null, null, clientFactory, null);
-      return githubRequestAdapter;
+        var clientFactory = ClientFactory.Create();
+        var githubRequestAdapter = new HttpClientRequestAdapter(authenticationProvider, null, null, clientFactory, null);
+        return githubRequestAdapter;
     }
 }

--- a/src/Middleware/APIVersionHandler.cs
+++ b/src/Middleware/APIVersionHandler.cs
@@ -1,3 +1,4 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
 
 using GitHub.Client.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
@@ -7,29 +8,23 @@ namespace GitHub.Client.Middleware;
 /// <summary>
 /// Represents a handler that adds the API version header to outgoing HTTP requests.
 /// </summary>
-class APIVersionHandler : DelegatingHandler
+class APIVersionHandler(APIVersionOptions? apiVersionOptions = null) : DelegatingHandler
 {
-  private const string ApiVersionHeaderKey = "X-GitHub-Api-Version";
+    private const string ApiVersionHeaderKey = "X-GitHub-Api-Version";
 
-  private readonly APIVersionOptions _apiVersionOptions;
+    private readonly APIVersionOptions _apiVersionOptions = apiVersionOptions ?? new APIVersionOptions();
 
-  public APIVersionHandler(APIVersionOptions? apiVersionOptions = null)
-  {
-      _apiVersionOptions = apiVersionOptions ?? new APIVersionOptions();
-  }
-
-  protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-  {
-    if (request == null){
-      throw new ArgumentNullException(nameof(request));
-    }
-
-    var apiVersionHandlerOption = request.GetRequestOption<APIVersionOptions>() ?? _apiVersionOptions;
-
-    if (!request.Headers.Contains(ApiVersionHeaderKey) || !request.Headers.GetValues(ApiVersionHeaderKey).Any(x => apiVersionHandlerOption.APIVersion.Equals(x, StringComparison.OrdinalIgnoreCase)))
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-      request.Headers.Add(ApiVersionHeaderKey, apiVersionHandlerOption.APIVersion);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var apiVersionHandlerOption = request.GetRequestOption<APIVersionOptions>() ?? _apiVersionOptions;
+
+        if (!request.Headers.Contains(ApiVersionHeaderKey) || !request.Headers.GetValues(ApiVersionHeaderKey).Any(x => apiVersionHandlerOption.APIVersion.Equals(x, StringComparison.OrdinalIgnoreCase)))
+        {
+            request.Headers.Add(ApiVersionHeaderKey, apiVersionHandlerOption.APIVersion);
+        }
+
+        return base.SendAsync(request, cancellationToken);
     }
-    return base.SendAsync(request, cancellationToken);
-  }
 }

--- a/src/Middleware/Options/APIVersionOptions.cs
+++ b/src/Middleware/Options/APIVersionOptions.cs
@@ -1,13 +1,20 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using Microsoft.Kiota.Abstractions;
 
 namespace GitHub.Client.Middleware.Options;
 
+/// <summary>
+/// Represents the API version options for the middleware.
+/// </summary>
 public class APIVersionOptions : IRequestOption
 {
-
+    /// <summary>
+    /// Gets or sets the API version for the request header.
+    /// </summary>
     public string APIVersion { get; set; } = GetAPIVersion();
 
-  private static string GetAPIVersion() =>
-    //TODO : Get the version from the generator
-    "2022-11-28";
+    private static string GetAPIVersion() =>
+      //TODO : Get the version from the generator
+      "2022-11-28";
 }

--- a/src/Middleware/Options/UserAgentOptions.cs
+++ b/src/Middleware/Options/UserAgentOptions.cs
@@ -1,10 +1,24 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using Microsoft.Kiota.Abstractions;
 
 namespace GitHub.Client.Middleware.Options;
 
+/// <summary>
+/// Represents the user agent options for the middleware.
+/// </summary>
 public class UserAgentOptions : IRequestOption
 {
-  private static string GetProductVersion() => "0.0.0";
-  public string ProductName { get; set; } = "dotnet-sdk";
-  public string ProductVersion { get; set; } = GetProductVersion();
+    /// <summary>
+    /// Gets or sets the product name used in the user agent request header.
+    /// Defaults to <c>"dotnet-sdk"</c>.
+    /// </summary>
+    public string ProductName { get; set; } = "dotnet-sdk";
+
+    /// <summary>
+    /// Gets or sets the product version used in the user agent request header.
+    /// </summary>
+    public string ProductVersion { get; set; } = GetProductVersion();
+
+    private static string GetProductVersion() => "0.0.0";
 }

--- a/src/Middleware/UserAgentHandler.cs
+++ b/src/Middleware/UserAgentHandler.cs
@@ -1,3 +1,5 @@
+// Copyright (c) GitHub 2023 — Licensed as MIT.
+
 using System.Net.Http.Headers;
 using GitHub.Client.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
@@ -5,19 +7,13 @@ using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
 
 namespace GitHub.Client.Middleware;
 
-public class UserAgentHandler : DelegatingHandler
+public class UserAgentHandler(UserAgentOptions? userAgentHandlerOption = null) : DelegatingHandler
 {
-    private readonly UserAgentOptions _userAgentOption;
-
-    public UserAgentHandler(UserAgentOptions? userAgentHandlerOption = null)
-    {
-        _userAgentOption = userAgentHandlerOption ?? new UserAgentOptions();
-    }
+    private readonly UserAgentOptions _userAgentOption = userAgentHandlerOption ?? new UserAgentOptions();
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if(request == null)
-            throw new ArgumentNullException(nameof(request));
+        ArgumentNullException.ThrowIfNull(request);
 
         var userAgentHandlerOption = request.GetRequestOption<UserAgentOptions>() ?? _userAgentOption;
 

--- a/src/Middleware/UserAgentHandler.cs
+++ b/src/Middleware/UserAgentHandler.cs
@@ -4,7 +4,6 @@ using System.Net.Http.Headers;
 using GitHub.Client.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
 
-
 namespace GitHub.Client.Middleware;
 
 public class UserAgentHandler(UserAgentOptions? userAgentHandlerOption = null) : DelegatingHandler

--- a/src/Octokit.NET.SDK.csproj
+++ b/src/Octokit.NET.SDK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Octokit.NET.SDK</PackageId>


### PR DESCRIPTION
In this PR:

- Add _.editorconfig_
- Apply file header, assumed copyright phrasing, inferred from .csproj
- Use primary constructors where possible
- Use collection expressions where it made sense
- Tried making code more readable
- Add files to _.sln_, makes them visible within Visual Studio
- Update _.gitignore_ to ignore the Visual Studio workspace directory
- Add triple slash comments to public APIs
- Use expression bodied members where possible
- Use `ArgumentNullException.Throw*` patterns
- General clean up and formating