### PR TITLE
feat: Adds test project with some basic tests, adds optional parameter to the RequestAdaptor

### DIFF
--- a/GitHub.Octokit.sln
+++ b/GitHub.Octokit.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{7EF0200D-9F10-4A77-8F73-3E26D3EBD326}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C118D1F2-D47D-4488-9D2F-88BA4A7729BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EF0200D-9F10-4A77-8F73-3E26D3EBD326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EF0200D-9F10-4A77-8F73-3E26D3EBD326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EF0200D-9F10-4A77-8F73-3E26D3EBD326}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EF0200D-9F10-4A77-8F73-3E26D3EBD326}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/Client/ClientFactoryTest.cs
+++ b/Tests/Client/ClientFactoryTest.cs
@@ -1,0 +1,22 @@
+using Xunit;
+using GitHub.Client;
+
+public class ClientFactoryTests
+{
+
+  [Fact]
+  public void Creates_Client_With_Default_Timeout()
+  {
+    var clientFactory = ClientFactory.Create();
+    Assert.Equal(TimeSpan.FromSeconds(100), clientFactory.Timeout);
+  }
+
+  [Fact]
+  public void Creates_Client_Persists_Set_Timeout()
+  {
+    var clientFactory = ClientFactory.Create();
+    clientFactory.Timeout = TimeSpan.FromSeconds(5);
+    Assert.Equal(TimeSpan.FromSeconds(5), clientFactory.Timeout);
+  }
+
+}

--- a/Tests/Client/RequestAdaptorTest.cs
+++ b/Tests/Client/RequestAdaptorTest.cs
@@ -1,0 +1,32 @@
+using Xunit;
+using GitHub.Client;
+using GitHub.Authentication;
+using NSubstitute;
+
+public class RequestAdapterTests
+{
+
+  [Fact]
+  public void Creates_RequestAdaptor_With_Defaults()
+  {
+    var requestAdapter = RequestAdapter.Create(new TokenAuthenticationProvider("Octokit.Gen", "JRRTOLKIEN"));
+    Assert.NotNull(requestAdapter);
+  }
+
+  [Fact]
+  public void Creates_RequestAdaptor_With_GenericHttpClient()
+  {
+    var httpClient = Substitute.For<HttpClient>();
+    var requestAdapter = RequestAdapter.Create(new TokenAuthenticationProvider("Octokit.Gen", "JRRTOLKIEN"), httpClient);
+    Assert.NotNull(requestAdapter);
+  }
+
+  [Fact]
+  public void Creates_RequestAdaptor_With_ClientFactory()
+  {
+    var clientFactory = ClientFactory.Create();
+    var requestAdapter = RequestAdapter.Create(new TokenAuthenticationProvider("Octokit.Gen", "JRRTOLKIEN"), clientFactory);
+    Assert.NotNull(requestAdapter);
+  }
+
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>GitHub .NET SDK Unit tests</Description>
+    <AssemblyTitle>Tests</AssemblyTitle>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Authors>GitHub</Authors>
+    <Copyright>Copyright (c) GitHub 2023</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="all" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Octokit.NET.SDK.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/xunit.runner.json
+++ b/Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "appDomain": "denied"
+}

--- a/src/Client/ClientFactory.cs
+++ b/src/Client/ClientFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 — Licensed as MIT.
+// Copyright (c) GitHub 2023 ï¿½ Licensed as MIT.
 
 using System.Net;
 using GitHub.Client.Middleware;

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) GitHub 2023 � Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions.Authentication;
-using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Http.HttpClientLibrary;
 
 namespace GitHub.Client;

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -1,22 +1,28 @@
-// Copyright (c) GitHub 2023 — Licensed as MIT.
+// Copyright (c) GitHub 2023 ï¿½ Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Http.HttpClientLibrary;
 
 namespace GitHub.Client;
 
 public static class RequestAdapter
 {
-    /// <summary>
+  /// <summary>
     /// Represents an adapter for making HTTP requests using HttpClient.
     /// </summary>
     /// TODO: Implement the missing props and methods
-    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider)
+    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, HttpClient? clientFactory = null)
     {
-        var clientFactory = ClientFactory.Create();
+        clientFactory ??= ClientFactory.Create();
 
-        var gitHubRequestAdapter = new HttpClientRequestAdapter(
-            authenticationProvider, null, null, clientFactory, null);
+        var gitHubRequestAdapter = 
+          new HttpClientRequestAdapter(
+            authenticationProvider,
+            null, // Node Parser
+            null, // Serializer
+            clientFactory, 
+            null);
         
         return gitHubRequestAdapter;
     }

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -9,21 +9,21 @@ namespace GitHub.Client;
 public static class RequestAdapter
 {
   /// <summary>
-    /// Represents an adapter for making HTTP requests using HttpClient.
-    /// </summary>
-    /// TODO: Implement the missing props and methods
-    public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, HttpClient? clientFactory = null)
-    {
-        clientFactory ??= ClientFactory.Create();
+  /// Represents an adapter for making HTTP requests using HttpClient.
+  /// </summary>
+  /// TODO: Implement the missing props and methods
+  public static HttpClientRequestAdapter Create(IAuthenticationProvider authenticationProvider, HttpClient? clientFactory = null)
+  {
+      clientFactory ??= ClientFactory.Create();
 
-        var gitHubRequestAdapter = 
-          new HttpClientRequestAdapter(
-            authenticationProvider,
-            null, // Node Parser
-            null, // Serializer
-            clientFactory, 
-            null);
-        
-        return gitHubRequestAdapter;
-    }
+      var gitHubRequestAdapter = 
+        new HttpClientRequestAdapter(
+          authenticationProvider,
+          null, // Node Parser
+          null, // Serializer
+          clientFactory, 
+          null);
+      
+      return gitHubRequestAdapter;
+  }
 }


### PR DESCRIPTION
Fixes: https://github.com/octokit/dotnet-sdk/issues/24


### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* There was no test project or tests
* The request adaptor could not receive a custom HttpClient

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* There are now tests
* Users can now pass in their own custom HttpClients and or instantiate a ClientFactory - this allows users to be able to set things like timeouts and custom headers 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

TODO: Add a CI step to run the unit tests
