### PR TITLE
Docs for releasing new versions

### DIFF
--- a/Docs/RELEASES.md
+++ b/Docs/RELEASES.md
@@ -1,14 +1,9 @@
-## Deploying a new release
+## Releasing this project
 
-### Requirements
+Creating a new release and deploying the package to Nuget are administrative tasks and require that you have admin rights to the [dotnet-sdk](https://github.com/octokit/dotnet-sdk) repository.
 
-Creating a new release and deploying the package to nuget are administrative tasks and require that you have/do the following:
-1. Admin rights to the [dotnet-sdk](https://github.com/octokit/dotnet-sdk) repository
+Periodically (based on the frequency of [this workflow](https://github.com/octokit/source-generator/blob/main/.github/workflows/build-dotnet.yml)), the source-generator repository will ingest the latest version of [GitHub's OpenAPI spec](https://github.com/github/rest-api-description) and generate a new version of this SDK. If there is a diff, a PR (similar to [this one](https://github.com/octokit/dotnet-sdk/pull/41)) will be generated.
 
-### Publish to nuget.org
+When reviewing the PR, analyze the diff and determine whether the changes are breaking (for which a major version number must be incremented), feature additions (for which a minor version number must be incremented), or bugfixes or docs changes (for which a patch number must be incremented). For more details about how to select an appropriate semantic version, see [semver.org](https://semver.org/). In many/most cases, due to the scale of GitHub's specification and the rate of change on it, the diff will be large and the changes will be technically breaking. This will mean incrementing a major version number.
 
-- Create a [new release](https://github.com/octokit/dotnet-sdk/releases/new) 
-  - Choose "create new tag" and use [SemVer](https://simver.org/) and the previous version to increment the version v#.#.#
-  - Generate release notes and clean them up 
-  - Check "Pre release" and submit
-
+When changes are analyzed, change the PR title appropriately (see [this PR](https://github.com/octokit/dotnet-sdk/pull/41) for an example) and merge it. Then go to [repository releases](https://github.com/octokit/dotnet-sdk/releases), tag the release with the chosen version, title it with the chosen version, use the "Autogenerate release notes" button to see what PRs will be included in the release, and manually edit the release notes as appropriate. After clicking "Publish Release", Actions will publish the release to Nuget and the new version will be available for use!


### PR DESCRIPTION
:eyes: [Rendered version](https://github.com/octokit/dotnet-sdk/blob/releasing-docs/Docs/RELEASES.md) :eyes: 

This PR is the dotnet-sdk side of https://github.com/octokit/go-sdk/pull/44. I stylized the dotnet packaging service "Nuget", is that correct? What else should change? 