### PR TITLE
Upgrade NuGet package versions to resolve Native AOT warnings.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,7 +152,7 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # License header
-file_header_template = Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+file_header_template = Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -152,7 +152,7 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # License header
-file_header_template = Copyright (c) GitHub 2023 — Licensed as MIT.
+file_header_template = Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,10 @@ defaults:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Octokit
+Copyright (c) 2023-2024 Octokit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Authentication/TokenAuthenticationProvider.cs
+++ b/src/Authentication/TokenAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;

--- a/src/Authentication/TokenAuthenticationProvider.cs
+++ b/src/Authentication/TokenAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;

--- a/src/Client/ClientFactory.cs
+++ b/src/Client/ClientFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using System.Net;
 using GitHub.Octokit.Client.Middleware;

--- a/src/Client/ClientFactory.cs
+++ b/src/Client/ClientFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using System.Net;
 using GitHub.Octokit.Client.Middleware;

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;

--- a/src/Client/RequestAdapter.cs
+++ b/src/Client/RequestAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;

--- a/src/GitHub.Octokit.SDK.csproj
+++ b/src/GitHub.Octokit.SDK.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
     <PackageId>GitHub.Octokit.SDK</PackageId>
     <Version>0.0.1-alpha</Version>
     <NuGetVersion>0.0.1-alpha</NuGetVersion>
@@ -18,13 +19,11 @@
 		<PackageIcon>octokit.png</PackageIcon>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
-    <Copyright>Copyright (c) GitHub 2023</Copyright>
+    <Copyright>Copyright (c) GitHub 2023-2024</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -34,14 +33,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.2" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.2" />
-    <None Include="NugetREADME.md" Pack="true" PackagePath="\"/>
-    <None Include="octokit.png" Pack="true" PackagePath="\"/>
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.11" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.7" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.5" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.8" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.4" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.4" />
+    <None Include="NugetREADME.md" Pack="true" PackagePath="\" />
+    <None Include="octokit.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/GitHub.Octokit.SDK.csproj
+++ b/src/GitHub.Octokit.SDK.csproj
@@ -15,9 +15,9 @@
     <Authors>GitHub</Authors>
     <PackageTags>GitHub API Octokit dotnet-core</PackageTags>
     <RepositoryUrl>https://github.com/octokit/dotnet-sdk</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/octokit/dotnet-sdk</PackageProjectUrl>
-		<PackageIcon>octokit.png</PackageIcon>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/octokit/dotnet-sdk</PackageProjectUrl>
+    <PackageIcon>octokit.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>NugetREADME.md</PackageReadmeFile>
     <Copyright>Copyright (c) GitHub 2023-2024</Copyright>
   </PropertyGroup>

--- a/src/Middleware/APIVersionHandler.cs
+++ b/src/Middleware/APIVersionHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using GitHub.Octokit.Client.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;

--- a/src/Middleware/APIVersionHandler.cs
+++ b/src/Middleware/APIVersionHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using GitHub.Octokit.Client.Middleware.Options;
 using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;

--- a/src/Middleware/Options/APIVersionOptions.cs
+++ b/src/Middleware/Options/APIVersionOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 

--- a/src/Middleware/Options/APIVersionOptions.cs
+++ b/src/Middleware/Options/APIVersionOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 

--- a/src/Middleware/Options/UserAgentOptions.cs
+++ b/src/Middleware/Options/UserAgentOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 

--- a/src/Middleware/Options/UserAgentOptions.cs
+++ b/src/Middleware/Options/UserAgentOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using Microsoft.Kiota.Abstractions;
 

--- a/src/Middleware/UserAgentHandler.cs
+++ b/src/Middleware/UserAgentHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using System.Net.Http.Headers;
 using GitHub.Octokit.Client.Middleware.Options;

--- a/src/Middleware/UserAgentHandler.cs
+++ b/src/Middleware/UserAgentHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023 - Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
 
 using System.Net.Http.Headers;
 using GitHub.Octokit.Client.Middleware.Options;

--- a/test/Authentication/TokenAuthenticationProviderTest.cs
+++ b/test/Authentication/TokenAuthenticationProviderTest.cs
@@ -1,3 +1,5 @@
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
+
 using GitHub.Octokit.Authentication;
 using Microsoft.Kiota.Abstractions;
 using Xunit;

--- a/test/Client/ClientFactoryTest.cs
+++ b/test/Client/ClientFactoryTest.cs
@@ -1,14 +1,14 @@
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
+
 using GitHub.Octokit.Client;
 using GitHub.Octokit.Client.Middleware;
 using Xunit;
-
 
 public class TestHandler1 : DelegatingHandler { }
 public class TestHandler2 : DelegatingHandler { }
 
 public class ClientFactoryTests
 {
-
     [Fact]
     public void Creates_Client_With_Default_Timeout()
     {
@@ -59,7 +59,4 @@ public class ClientFactoryTests
         var handler = ClientFactory.GetDefaultHttpMessageHandler();
         Assert.NotNull(handler);
     }
-
 }
-
-

--- a/test/Client/RequestAdaptorTest.cs
+++ b/test/Client/RequestAdaptorTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+// Copyright (c) GitHub 2023-2024 - Licensed as MIT.
 
 using GitHub.Octokit.Authentication;
 using GitHub.Octokit.Client;
@@ -6,7 +6,6 @@ using Xunit;
 
 public class RequestAdapterTests
 {
-
     [Fact]
     public void Creates_RequestAdaptor_With_Defaults()
     {
@@ -29,5 +28,4 @@ public class RequestAdapterTests
         var requestAdapter = RequestAdapter.Create(new TokenAuthenticationProvider("Octokit.Gen", "JRRTOLKIEN"), clientFactory);
         Assert.NotNull(requestAdapter);
     }
-
 }

--- a/test/Client/RequestAdaptorTest.cs
+++ b/test/Client/RequestAdaptorTest.cs
@@ -1,3 +1,5 @@
+// Copyright (c) GitHub 2023-2024 — Licensed as MIT.
+
 using GitHub.Octokit.Authentication;
 using GitHub.Octokit.Client;
 using Xunit;

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>GitHub</Authors>
-    <Copyright>Copyright (c) GitHub 2023</Copyright>
+    <Copyright>Copyright (c) GitHub 2023-2024</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -37,9 +37,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -44,11 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\GitHub.Octokit.SDK.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Upgrade NuGet package versions to resolve Native AOT warnings.
- Update copyright dates.
- Remove `strategy: fail-fast: false` as the workflow isn't a matrix.
- Update to `actions/checkout@v3`.