### PR TITLE
Use default Kiota middleware in client

### DIFF
--- a/src/Client/ClientFactory.cs
+++ b/src/Client/ClientFactory.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using GitHub.Octokit.Client.Middleware;
+using Microsoft.Kiota.Http.HttpClientLibrary;
 
 namespace GitHub.Octokit.Client;
 
@@ -39,7 +40,13 @@ public static class ClientFactory
     /// Creates a list of default delegating handlers for the Octokit client.
     /// </summary>
     /// <returns>A list of default delegating handlers.</returns>
-    public static IList<DelegatingHandler> CreateDefaultHandlers() => s_handlers.Value;
+    public static IList<DelegatingHandler> CreateDefaultHandlers()
+    {
+        var defaultHandlers = s_handlers.Value;
+        var kiotaDefaultHandlers = KiotaClientFactory.CreateDefaultHandlers();
+
+        return kiotaDefaultHandlers.Concat(defaultHandlers).ToList();
+    }
 
     /// <summary>
     /// Chains a collection of <see cref="DelegatingHandler"/> instances and returns the first link in the chain.

--- a/test/Client/ClientFactoryTest.cs
+++ b/test/Client/ClientFactoryTest.cs
@@ -39,6 +39,10 @@ public class ClientFactoryTests
         Assert.Contains(handlers, h => h is APIVersionHandler);
         Assert.Contains(handlers, h => h is UserAgentHandler);
         Assert.Contains(handlers, h => h is RateLimitHandler);
+
+        // Assert that the Kiota retry handler and redirect handler are present as well
+        Assert.Contains(handlers, h => h is Microsoft.Kiota.Http.HttpClientLibrary.Middleware.RetryHandler);
+        Assert.Contains(handlers, h => h is Microsoft.Kiota.Http.HttpClientLibrary.Middleware.RedirectHandler);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

The go-sdk was using the default Kiota middleware before applying our own default middlewares before applying any user-defined middleware. This change modifies the dotnet-sdk to do the same, giving us the benefit of the default Kiota redirect and retry middlewares, among others. For a full list, see [here](https://github.com/microsoft/kiota-http-dotnet/blob/1e2aa482bca9e633be186790ab5b5f9bfeebeb29/src/KiotaClientFactory.cs#L50).

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The default Kiota middlewares were not used in the client.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The default middlewares are applied in the client.

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

